### PR TITLE
Pipeline

### DIFF
--- a/bin/launch_convolution_scan.py
+++ b/bin/launch_convolution_scan.py
@@ -21,7 +21,7 @@ def get_args():
     parser.add_argument("-i", "--infasta", type=str, required=True, metavar="FILE", help='The file path for the DNA sequences in fasta format.')
     parser.add_argument("-hp", "--hyper_params", type=str, required=True, metavar="FILE", help='The file path for the hyper parameters of the model.')
     parser.add_argument("-p", "--params", type=str, required=True, metavar="FILE", help='The file path for the parameters of the model.')
-    parser.add_argument("-o", "--output", type=str, required=False, metavar="FILE", default="output/", help='The file path for the output folder.')
+    parser.add_argument("-o", "--output", type=str, required=False, nargs='?', const='', default='', metavar="FILE", help='The file path for the output folder. Or better the string to be placed in front the standard filename, so if it contains a slash is treated as dir otherwise as simple prefix.')
     parser.add_argument("--modules_version", type=str, required=False, nargs='?', const='False', default='False', metavar='VERBOSE', help='auxiliary flag top check module version used byt this script.')
     args = parser.parse_args()
     return args

--- a/bin/src/learner/tune_trainer.py
+++ b/bin/src/learner/tune_trainer.py
@@ -57,7 +57,7 @@ class Trainer(ABC):
             output = model(data)
 
             # reshape output to match target shape
-            output = output.view(target.shape[0], -1)
+            output = output.view(target.shape[0])
             loss = self.loss_function(output, target)
             loss.backward()
             optimizer.step()

--- a/configs/local.config
+++ b/configs/local.config
@@ -1,3 +1,35 @@
+params {
+  config_profile_name = 'Local profile'
+  config_profile_description = 'Configuration to run on local machine'
+
+  max_cpus = 6
+  max_memory = 8.GB
+  max_time   = 24.h
+}
+
+
+
+process {
+    maxRetries = params.max_retries
+    errorStrategy = params.err_start
+
+    withLabel:process_low {
+          cpus   = { check_max( 1                  , 'cpus'    ) }
+          memory = { check_max( 4.GB * task.attempt, 'memory'  ) }
+          time   = { check_max( 1.h  * task.attempt, 'time'    ) }
+       }
+    withLabel:process_medium{
+          cpus   = { check_max( 4                  , 'cpus'    ) }
+          memory = { check_max( 10.GB * task.attempt, 'memory'  ) }
+          time   = { check_max( 6.h  * task.attempt, 'time'    ) }
+    }
+    withLabel:process_medium_high {
+          cpus   = { check_max( 12                  , 'cpus'    ) }
+          memory = { check_max( 50.GB * task.attempt, 'memory'  ) }
+          time   = { check_max( 12.h  * task.attempt, 'time'    ) }
+    }
+}
+
 
 docker {
     enabled = true

--- a/configs/local.config
+++ b/configs/local.config
@@ -34,4 +34,7 @@ process {
 docker {
     enabled = true
     cacheDir = 'docker_cache'
+
+    // the following line is a prototype to fix a warning on the usage of /tmp instead of /dev/shm by Ray tuner
+    //runOptions = '--shm-size=1.84gb'
 }

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -44,11 +44,6 @@ process {
                        params.optimizer_lr   ? "-olr ${params.optimizer_lr}"  : '-olr 1e-4,0.01'
                        ].flatten().unique(false).join(' ').trim()
         }
-	publishDir = [
-            path: { "${params.outdir}/model" },
-            mode: params.publish_dir_mode,
-            overwrite: true
-        ]
     }
 
     withName: PLOT_MODEL_WEIGHTS {

--- a/main.nf
+++ b/main.nf
@@ -31,7 +31,7 @@ workflow {
 
     // TODO make a nicer print of the filename
     // TODO write all parameters flags to log file
-	
+    	
     HANDLE_FASTA()
     fasta          = HANDLE_FASTA.out.fasta
     fasta_message  = HANDLE_FASTA.out.completition_message 
@@ -42,24 +42,24 @@ workflow {
     jaspar_message = JASPAR_DOWNLOAD.out.completition_message
     jaspar_message.view()
     
-    CHECK_TRAINABLE( fasta )
+    CHECK_TRAINABLE( fasta.first() )
     check_message  = CHECK_TRAINABLE.out.message
     check_message.view()
-
+    
     TRAIN( fasta, check_message )
     train_message  = TRAIN.out.message
     architecture   = TRAIN.out.architecture
     trained_model  = TRAIN.out.trained_model
     train_message.view()
-
+    
     VERIFY_TRAINED( fasta, architecture, trained_model, jaspar_db )
     verify_message = VERIFY_TRAINED.out.completition_message
     verify_message.view()    
-
+    
     PLOT_MODEL( architecture, trained_model )
     plot_message = PLOT_MODEL.out.message
     plot_message.view()
-
+    
 }
 
 workflow.onComplete {

--- a/modules/convolution_scan.nf
+++ b/modules/convolution_scan.nf
@@ -3,12 +3,10 @@ process CONVOLUTION_SCAN {
 
     container 'alessiovignoli3/model-check:dataload_training'
     label 'process_low'
-    tag "${fasta}"
+    tag "${dir_ID}"
 
     input:
-    path fasta
-    path hyperparameter
-    path parameter
+    tuple val(dir_ID), path(fasta), path(hyperparameter), path(parameter)
 
     output:
     path( "*positive*.fasta" ), emit: positve_set
@@ -17,11 +15,13 @@ process CONVOLUTION_SCAN {
 
     script:
     """
-    launch_convolution_scan.py -i ${fasta} -hp ${hyperparameter} -p ${parameter} -o PLACEHOLDER
+    # the output prefix is appended with 2 _ for splitting reason later in the pipeline
+    launch_convolution_scan.py -i ${fasta} -hp ${hyperparameter} -p ${parameter} -o "${dir_ID}__"
     """
 
     stub:
     """
-    launch_convolution_scan.py -i ${fasta} -hp ${hyperparameter} -p ${parameter} -o PLACEHOLDER_ --modules_version True
+    # the output prefix is appended with 2 _ for splitting reason later in the pipeline
+    launch_convolution_scan.py -i ${fasta} -hp ${hyperparameter} -p ${parameter} -o "${dir_ID}__" --modules_version True
     """
 }

--- a/modules/generate_fasta.nf
+++ b/modules/generate_fasta.nf
@@ -10,7 +10,7 @@ process GENERATE_FASTA {
     val type_of_file_flag
 
     output:
-    path "${dir_ID}", emit: dna_dir, type: 'dir'
+    tuple val(dir_ID), path("${dir_ID}", type: 'dir'), emit: dna_dir
     stdout emit: standardout  
 
     script:

--- a/modules/generate_fasta.nf
+++ b/modules/generate_fasta.nf
@@ -10,12 +10,12 @@ process GENERATE_FASTA {
     val type_of_file_flag
 
     output:
-    tuple val(dir_ID), path("${dir_ID}", type: 'dir'), emit: dna_dir
+    tuple val(dir_ID), path("${dir_ID}/${prefix}"), emit: dna_dir
     stdout emit: standardout  
 
     script:
     def args = task.ext.args ?: ""
-    def prefix = task.ext.prefix ?: "generated.fasta"
+    prefix = task.ext.prefix ?: "generated.fasta"
     """
     launch_fasta_generate.py ${type_of_file_flag} ${motif_file} -o ${prefix} ${args} 
     mkdir ${dir_ID}
@@ -24,7 +24,7 @@ process GENERATE_FASTA {
 
     stub:
     def args = task.ext.args ?: ""
-    def prefix = task.ext.prefix ?: "generated.fasta"
+    prefix = task.ext.prefix ?: "generated.fasta"
     """
     launch_fasta_generate.py ${type_of_file_flag} ${motif_file} -o ${prefix} ${args} --modules_version True
     mkdir ${dir_ID}

--- a/modules/generate_fasta.nf
+++ b/modules/generate_fasta.nf
@@ -3,13 +3,14 @@ process GENERATE_FASTA {
 
     container "alessiovignoli3/model-check:generate_fasta"
     label "process_low"
+    tag "${motif_file}"
 
     input:
-    path motif_file
+    tuple val(dir_ID), path(motif_file)
     val type_of_file_flag
 
     output:
-    path "*", emit: dna_fasta
+    path "${dir_ID}", emit: dna_dir, type: 'dir'
     stdout emit: standardout  
 
     script:
@@ -17,6 +18,8 @@ process GENERATE_FASTA {
     def prefix = task.ext.prefix ?: "generated.fasta"
     """
     launch_fasta_generate.py ${type_of_file_flag} ${motif_file} -o ${prefix} ${args} 
+    mkdir ${dir_ID}
+    mv  ${prefix}  ${dir_ID}
     """
 
     stub:
@@ -24,6 +27,8 @@ process GENERATE_FASTA {
     def prefix = task.ext.prefix ?: "generated.fasta"
     """
     launch_fasta_generate.py ${type_of_file_flag} ${motif_file} -o ${prefix} ${args} --modules_version True
+    mkdir ${dir_ID}
+    mv  ${prefix}  ${dir_ID}
     """
 
 }

--- a/modules/generate_fasta.nf
+++ b/modules/generate_fasta.nf
@@ -3,7 +3,7 @@ process GENERATE_FASTA {
 
     container "alessiovignoli3/model-check:generate_fasta"
     label "process_low"
-    tag "${motif_file}"
+    tag "${dir_ID}"
 
     input:
     tuple val(dir_ID), path(motif_file)

--- a/modules/generate_from_fasta.nf
+++ b/modules/generate_from_fasta.nf
@@ -3,14 +3,14 @@ process GENERATE_FROM_FASTA {
 
     container "alessiovignoli3/model-check:generate_fasta"
     label "process_low"
+    tag "${motif_file}"
 
     input:
-    path motif_file
-    path base_fasta
+    tuple val(dir_ID), path(motif_file), path(base_fasta)
     val type_of_file_flag
 
     output:
-    path "*", emit: dna_fasta
+    path "${dir_ID}", emit: dna_dir, type: 'dir'
     stdout emit: standardout
 
     script:
@@ -18,6 +18,8 @@ process GENERATE_FROM_FASTA {
     def prefix = task.ext.prefix ?: "generated.fasta"
     """
     launch_fasta_generate.py ${type_of_file_flag} ${motif_file} -o ${prefix} -f ${base_fasta} ${args}
+    mkdir ${dir_ID}
+    mv  ${prefix}  ${dir_ID}
     """
 
     stub:
@@ -25,6 +27,8 @@ process GENERATE_FROM_FASTA {
     def prefix = task.ext.prefix ?: "generated.fasta"
     """
     launch_fasta_generate.py ${type_of_file_flag} ${motif_file} -o ${prefix} -f ${base_fasta} ${args} --modules_version True
+    mkdir ${dir_ID}
+    mv  ${prefix}  ${dir_ID}
     """
 
 }

--- a/modules/generate_from_fasta.nf
+++ b/modules/generate_from_fasta.nf
@@ -10,12 +10,12 @@ process GENERATE_FROM_FASTA {
     val type_of_file_flag
 
     output:
-    tuple val(dir_ID), path("${dir_ID}",  type: 'dir'), emit: dna_dir
+    tuple val(dir_ID), path("${dir_ID}/${prefix}"), emit: dna_dir
     stdout emit: standardout
 
     script:
     def args = task.ext.args ?: ""
-    def prefix = task.ext.prefix ?: "generated.fasta"
+    prefix = task.ext.prefix ? task.ext.prefix : "generated.fasta"
     """
     launch_fasta_generate.py ${type_of_file_flag} ${motif_file} -o ${prefix} -f ${base_fasta} ${args}
     mkdir ${dir_ID}
@@ -24,7 +24,7 @@ process GENERATE_FROM_FASTA {
 
     stub:
     def args = task.ext.args ?: ""
-    def prefix = task.ext.prefix ?: "generated.fasta"
+    prefix = task.ext.prefix ? task.ext.prefix : "generated.fasta"
     """
     launch_fasta_generate.py ${type_of_file_flag} ${motif_file} -o ${prefix} -f ${base_fasta} ${args} --modules_version True
     mkdir ${dir_ID}

--- a/modules/generate_from_fasta.nf
+++ b/modules/generate_from_fasta.nf
@@ -3,7 +3,7 @@ process GENERATE_FROM_FASTA {
 
     container "alessiovignoli3/model-check:generate_fasta"
     label "process_low"
-    tag "${motif_file}"
+    tag "${dir_ID}"
 
     input:
     tuple val(dir_ID), path(motif_file), path(base_fasta)

--- a/modules/generate_from_fasta.nf
+++ b/modules/generate_from_fasta.nf
@@ -10,7 +10,7 @@ process GENERATE_FROM_FASTA {
     val type_of_file_flag
 
     output:
-    path "${dir_ID}", emit: dna_dir, type: 'dir'
+    tuple val(dir_ID), path("${dir_ID}",  type: 'dir'), emit: dna_dir
     stdout emit: standardout
 
     script:

--- a/modules/homer_find_jaspar_motif.nf
+++ b/modules/homer_find_jaspar_motif.nf
@@ -5,29 +5,29 @@ process HOMER_FIND_JASPAR_MOTIF {
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/homer:4.11--pl526hc9558a2_3' :
         'biocontainers/homer:4.11--pl526hc9558a2_3' }"                                                   // homer 4.11 and perl 5.26.2
+    publishDir path: "${params.outdir}/${dir_ID}/filter_${filter_num}", mode: "${params.publish_dir_mode}", overwrite: true
     label "process_medium"
-    tag "${id}"
+    tag "${dir_ID}-${filter_num}"
 
     input:
-    tuple val(id), val(filter_len), path(positve_set), path(negative_set)
-    val jaspar_db
+    tuple val(dir_ID), val(filter_num), val(filter_len), path(positve_set), path(negative_set), path(jaspar_db)
 
     output:
-    //path( "*positive*.fasta" ), emit: positve_set
+    path( "homerResults" ),type: 'dir', emit: positve_set
     stdout emit: standardout
 
     script:
     """
-    findMotifs.pl ${positve_set} fasta tmp -fasta ${negative_set} -len ${filter_len} -norevopp -mcheck ${jaspar_db} -mknown ${jaspar_db}
+    findMotifs.pl ${positve_set} fasta . -fasta ${negative_set} -len ${filter_len} -norevopp -mcheck ${jaspar_db} -mknown ${jaspar_db}
     """
 
     stub:
     """
     # print versions
     perl -X --version | grep 'This is perl'
-    echo homer version (10-24-2019)
+    echo 'homer version (10-24-2019)'
 
     # create the expected dirs and outputs
-    mkdir -p tmp/homerResults
+    mkdir -p homerResults
     """
 }

--- a/modules/homer_find_motif.nf
+++ b/modules/homer_find_motif.nf
@@ -6,10 +6,10 @@ process HOMER_FIND_MOTIF {
         'https://depot.galaxyproject.org/singularity/homer:4.11--pl526hc9558a2_3' :
         'biocontainers/homer:4.11--pl526hc9558a2_3' }"                                                   // homer 4.11 and perl 5.26.2
     label "process_medium"
-    tag "${id}"
+    tag "${dir_ID}-${filter_num}"
 
     input:
-    tuple val(id), val(filter_len), path(positve_set), path(negative_set)
+    tuple val(dir_ID), val(filter_num), val(filter_len), path(positve_set), path(negative_set)
 
     output:
     //path( "*positive*.fasta" ), emit: positve_set

--- a/modules/jaspar_to_homer.nf
+++ b/modules/jaspar_to_homer.nf
@@ -3,13 +3,13 @@ process  JASPAR_TO_HOMER {
 
     container "alessiovignoli3/model-check:pwm2homer" 
     label 'process_low'
-    tag "${jaspar_pwm_file}"
+    tag "${dir_ID}"
 
     input:
-    tuple val(line_ID), path(jaspar_pwm_file)
+    tuple val(dir_ID), path(jaspar_pwm_file)
 
     output:
-    tuple val(line_ID), path("${out_name}"), emit: homer_matrix
+    tuple val(dir_ID), path("${out_name}"), emit: homer_matrix
     stdout emit: standardout
 
     script:

--- a/modules/jaspar_to_homer.nf
+++ b/modules/jaspar_to_homer.nf
@@ -6,10 +6,10 @@ process  JASPAR_TO_HOMER {
     tag "${jaspar_pwm_file}"
 
     input:
-    path jaspar_pwm_file
+    tuple val(line_ID), path(jaspar_pwm_file)
 
     output:
-    path "${out_name}", emit: homer_matrix
+    tuple val(line_ID), path("${out_name}"), emit: homer_matrix
     stdout emit: standardout
 
     script:

--- a/modules/one_step_train.nf
+++ b/modules/one_step_train.nf
@@ -6,7 +6,7 @@ process ONE_STEP_TRAIN {
     tag "${fasta}"
 
     input:
-    path fasta
+    tuple val(dir_ID), path(fasta)
 
     output:
     stdout emit: standardout

--- a/modules/one_step_train.nf
+++ b/modules/one_step_train.nf
@@ -3,7 +3,7 @@ process ONE_STEP_TRAIN {
 
     container 'alessiovignoli3/model-check:dataload_training'
     label 'process_low'
-    tag "${fasta}"
+    tag "${dir_ID}"
 
     input:
     tuple val(dir_ID), path(fasta)

--- a/modules/query_jaspar.nf
+++ b/modules/query_jaspar.nf
@@ -9,7 +9,7 @@ process QUERY_JASPAR {
     tuple val(line_ID), val(jaspar_motif_id)
 
     output:
-    path "*.jaspar", emit: jaspar_pwm, optional: true
+    tuple val(line_ID), path("*.jaspar"), emit: jaspar_pwm, optional: true
     stdout emit: standardout
 
     script:

--- a/modules/query_jaspar.nf
+++ b/modules/query_jaspar.nf
@@ -3,18 +3,18 @@ process QUERY_JASPAR {
 
     container "alessiovignoli3/tango-project@sha256:57013bf372b519245608c95fd60a38f9e5d65775aaf18c2d711031818c1a145e"     // bash5.0.17 with awk and wget
     label "process_low"
-    tag "${line_ID}"
+    tag "${dir_ID}"
 
     input:
-    tuple val(line_ID), val(jaspar_motif_id)
+    tuple val(dir_ID), val(jaspar_motif_id)
 
     output:
-    tuple val(line_ID), path("*.jaspar"), emit: jaspar_pwm, optional: true
+    tuple val(dir_ID), path("*.jaspar"), emit: jaspar_pwm, optional: true
     stdout emit: standardout
 
     script:
     """
-    touch motif_${line_ID}.jaspar
+    touch ${dir_ID}.jaspar
     
     for motif_id in ${jaspar_motif_id}
     do
@@ -27,16 +27,16 @@ process QUERY_JASPAR {
             then
                 echo "###  WARNING   motif ID not found : " \$motif_id
             else
-                cat tmp_\$motif_id >> motif_${line_ID}.jaspar
+                cat tmp_\$motif_id >> ${dir_ID}.jaspar
                 rm tmp_\$motif_id
         fi
     done
 
     # if no id was found there will be no output file so a message can be sent to user
-    if ! [ -s motif_${line_ID}.jaspar ]
+    if ! [ -s ${dir_ID}.jaspar ]
     then
-        echo "###  WARNING   no motif ID was found for this line -> ${line_ID}"
-        rm motif_${line_ID}.jaspar
+        echo "###  WARNING   no motif ID was found for this line -> ${dir_ID}"
+        rm ${dir_ID}.jaspar
     else
         exit 0                                          ## exiting with no error
     fi
@@ -44,7 +44,7 @@ process QUERY_JASPAR {
 
     stub:
     """
-    touch motif_${line_ID}.jaspar
+    touch ${dir_ID}.jaspar
 
     for motif_id in ${jaspar_motif_id}
     do
@@ -57,16 +57,16 @@ process QUERY_JASPAR {
             then
                 echo "###  WARNING   motif ID not found : " \$motif_id
             else
-                cat tmp_\$motif_id >> motif_${line_ID}.jaspar
+                cat tmp_\$motif_id >> ${dir_ID}.jaspar
                 rm tmp_\$motif_id
         fi
     done
     
     # if no id was found there will be no output file so a message can be sent to user
-    if ! [ -s motif_${line_ID}.jaspar ]
+    if ! [ -s ${dir_ID}.jaspar ]
     then
-        echo "###  WARNING   no motif ID was found for this line -> ${line_ID}"
-        rm motif_${line_ID}.jaspar
+        echo "###  WARNING   no motif ID was found for this line -> ${dir_ID}"
+        rm ${dir_ID}.jaspar
     else
         exit 0                                          ## exiting with no error
     fi

--- a/modules/train_model.nf
+++ b/modules/train_model.nf
@@ -1,17 +1,18 @@
 
 process TRAIN_MODEL {
 
+    publishDir path: "${params.outdir}/${dir_ID}", mode: "${params.publish_dir_mode}", overwrite: true
     container 'alessiovignoli3/model-check:dataload_training'
     label 'process_medium_high'
     tag "${fasta}"
 
     input:
-    path fasta
+    tuple val(dir_ID), path(fasta)
 
     output:
-    path "*.pt", emit: best_model
-    path "train_statistics.txt", emit: statistics
-    path "architecture.txt", emit: architecture
+    tuple val(dir_ID), path("*.pt"), emit: best_model
+    tuple val(dir_ID), path("train_statistics.txt"), emit: statistics
+    tuple val(dir_ID), path("architecture.txt"), emit: architecture
     stdout emit: standardout
 
     script:

--- a/modules/train_model.nf
+++ b/modules/train_model.nf
@@ -8,6 +8,7 @@ process TRAIN_MODEL {
 
     input:
     tuple val(dir_ID), path(fasta)
+    val passed_check                         // used just to enforce dependency from the check train step
 
     output:
     tuple val(dir_ID), path("*.pt"), emit: best_model

--- a/modules/train_model.nf
+++ b/modules/train_model.nf
@@ -4,7 +4,7 @@ process TRAIN_MODEL {
     publishDir path: "${params.outdir}/${dir_ID}", mode: "${params.publish_dir_mode}", overwrite: true
     container 'alessiovignoli3/model-check:dataload_training'
     label 'process_medium_high'
-    tag "${fasta}"
+    tag "${dir_ID}"
 
     input:
     tuple val(dir_ID), path(fasta)

--- a/workflows/handle_fasta.nf
+++ b/workflows/handle_fasta.nf
@@ -37,7 +37,7 @@ workflow HANDLE_FASTA {
 
 
     if ( params.input_fasta ) {
-        fasta = Channel.fromPath( params.input_fasta )
+        fasta = Channel.fromPath( params.input_fasta ).map{ it -> [ it.baseName, it ] }
         completition_message = "\n# fasta file used for the training   : ${params.input_fasta}\n"
 
 

--- a/workflows/handle_fasta.nf
+++ b/workflows/handle_fasta.nf
@@ -19,7 +19,6 @@ workflow HANDLE_FASTA {
 
     main:
 
-
     // first create a channel for the base fasta file if necessary
     // this file is the one used to enrich on 
     // in case is missing an empty channel is created instead to comply with the input declaration of the GENERATE_FASTA process
@@ -29,10 +28,12 @@ workflow HANDLE_FASTA {
     }
 
 
+
+
     // the folowing variables act as switches or have different behavior in case 
     // the generation of the fasta is not needed
     fasta                = ''
-    completition_message = "\n# fasta file used for the training   : ${params.outdir}/generated.fasta\n"
+    completition_message = "\n# fasta file used for the training can be found at  : ${params.outdir}"
 
 
     if ( params.input_fasta ) {
@@ -40,30 +41,48 @@ workflow HANDLE_FASTA {
         completition_message = "\n# fasta file used for the training   : ${params.input_fasta}\n"
 
 
-    } else if ( params.jaspar ) {
-        jaspar_id_file = Channel.fromPath( params.jaspar )
 
+    } else if ( params.jaspar ) {
+
+        // Read the file line by line and create as many files as there are lines, each file containing one line from the original.
+        // the only tricky part is creating a unique name containing the source file and line#num_line in it  
+        jaspar_id_file = Channel.fromPath( params.jaspar ).splitText( file: true ).map{
+                                               it
+                                                    -> [ ( it.baseName.split('\\.')[0..-2].join("_") + "_line" + it.baseName.split('\\.')[-1]  ), 
+                                                        it] }
+       
 	if ( params.generate_from_fasta ) {
-		GENERATE_FROM_FASTA( jaspar_id_file, base_fasta, '-j' )
-		fasta = GENERATE_FROM_FASTA.out.dna_fasta
-		GENERATE_FROM_FASTA.out.standardout.view()
+                
+                // to make the next process execute the correct number of times base_fasta has to be adde to the tuple created above
+                input_files = jaspar_id_file.combine( base_fasta )
+
+                GENERATE_FROM_FASTA( input_files, '-j' )
+                fasta = GENERATE_FROM_FASTA.out.dna_dir
+                GENERATE_FROM_FASTA.out.standardout.view()
 	} else {
         	GENERATE_FASTA( jaspar_id_file, '-j' )
-        	fasta = GENERATE_FASTA.out.dna_fasta
+        	fasta = GENERATE_FASTA.out.dna_dir
        		GENERATE_FASTA.out.standardout.view()
 	}
+       
 
 
     } else if ( params.motif ) {
-        motif_file =  Channel.fromPath( params.motif )
+        motif_file =  Channel.fromPath( params.motif ).splitText( file: true ).map{
+                                               it
+                                                    -> [ ( it.baseName.split('\\.')[0..-2].join("_") + "_line" + it.baseName.split('\\.')[-1]  ),
+                                                        it] }
 
 	if ( params.generate_from_fasta ) {
-		GENERATE_FROM_FASTA( motif_file, base_fasta, '-m' )
-                fasta = GENERATE_FROM_FASTA.out.dna_fasta
+
+                input_files = motif_file.combine( base_fasta )
+
+		GENERATE_FROM_FASTA( input_files, '-m' )
+                fasta = GENERATE_FROM_FASTA.out.dna_dir
                 GENERATE_FROM_FASTA.out.standardout.view()
 	} else {
 		GENERATE_FASTA( motif_file, '-m' )
-        	fasta = GENERATE_FASTA.out.dna_fasta
+        	fasta = GENERATE_FASTA.out.dna_dir
         	GENERATE_FASTA.out.standardout.view()
 	}
 

--- a/workflows/jaspar_download.nf
+++ b/workflows/jaspar_download.nf
@@ -49,9 +49,9 @@ workflow JASPAR_DOWNLOAD {
         
         // transform jaspar output into homer readable one
         JASPAR_TO_HOMER( jaspar_pwm )
-        db                   = JASPAR_TO_HOMER.out.homer_matrix
+        db                   =  JASPAR_TO_HOMER.out.homer_matrix
         JASPAR_TO_HOMER.out.standardout.first().view()
-        
+    
     }
 
 

--- a/workflows/jaspar_download.nf
+++ b/workflows/jaspar_download.nf
@@ -35,14 +35,14 @@ workflow JASPAR_DOWNLOAD {
                                                it
                                                     -> [ ( it.baseName.split('\\.')[0..-2].join("_") + "_line" + it.baseName.split('\\.')[-1]  ),
                                                         it] }
-        // this line now splits the files of already one line to get to a list of motifs etting rid of missing fields and empty lines
+        // this line now splits the files of already one line to get to a list of motifs getting rid of missing fields and empty lines
         motif_line           = tmp_line_file.splitCsv( elem: 1, strip: true ).map{ 
                                                it 
                                                     -> [ it[0], (it[1] - '') ] }.filter{ it[1] != [] }.map{
                                                it
                                                     -> [ it[0], it[1].join(" ")] }
 
-        
+
         QUERY_JASPAR( motif_line )
         jaspar_pwm           = QUERY_JASPAR.out.jaspar_pwm
         completition_message = QUERY_JASPAR.out.standardout.filter{ it != '' }

--- a/workflows/jaspar_download.nf
+++ b/workflows/jaspar_download.nf
@@ -27,19 +27,31 @@ workflow JASPAR_DOWNLOAD {
 
     } else {
 
-        // get to motif id level, because that is what is going to be downloaded
+        // get to motif file line level, because that is what is going to be downloaded, (each motif ID per line)
+        // then appended to the same file all the motifs in the same line in the original motif file in the process
         jaspar_id_file       = Channel.fromPath( params.jaspar )
-        motif_id             = jaspar_id_file.splitCsv( strip: true ).flatten().filter{ it != '' }
+ 	// this line gets filename and line num correctly making it the ID
+        tmp_line_file        = jaspar_id_file.splitText( file: true ).map{
+                                               it
+                                                    -> [ ( it.baseName.split('\\.')[0..-2].join("_") + "_line" + it.baseName.split('\\.')[-1]  ),
+                                                        it] }
+        // this line now splits the files of already one line to get to a list of motifs etting rid of missing fields and empty lines
+        motif_line           = tmp_line_file.splitCsv( elem: 1, strip: true ).map{ 
+                                               it 
+                                                    -> [ it[0], (it[1] - '') ] }.filter{ it[1] != [] }.map{
+                                               it
+                                                    -> [ it[0], it[1].join(" ")] }
 
-        QUERY_JASPAR( motif_id )
+        
+        QUERY_JASPAR( motif_line )
         jaspar_pwm           = QUERY_JASPAR.out.jaspar_pwm
         completition_message = QUERY_JASPAR.out.standardout.filter{ it != '' }
-
-        // transform jaspaer output into homer readable one
+        
+        // transform jaspar output into homer readable one
         JASPAR_TO_HOMER( jaspar_pwm )
         db                   = JASPAR_TO_HOMER.out.homer_matrix
         JASPAR_TO_HOMER.out.standardout.first().view()
-
+        
     }
 
 

--- a/workflows/train.nf
+++ b/workflows/train.nf
@@ -21,8 +21,8 @@ workflow TRAIN {
     passed_check			// used just to enforce dependency from the check train step 
 
     main:
- 
-    TRAIN_MODEL(fasta)
+
+    TRAIN_MODEL(fasta, passed_check)
     trained_model = TRAIN_MODEL.out.best_model
     statistics    = TRAIN_MODEL.out.statistics
     message       = TRAIN_MODEL.out.standardout

--- a/workflows/verify_trained.nf
+++ b/workflows/verify_trained.nf
@@ -31,7 +31,7 @@ workflow VERIFY_TRAINED {
     completition_message = ''
     
     if ( params.skip_homer || params.input_fasta ) {
-        //completition_message = '\n# skipped homer for verifying motif learnt by model\n'
+        completition_message = '\n# skipped homer for verifying motif learnt by model\n'
 
     } else {
         CONVOLUTION_SCAN( input_fasta, model_architecture, trained_model )

--- a/workflows/verify_trained.nf
+++ b/workflows/verify_trained.nf
@@ -29,41 +29,55 @@ workflow VERIFY_TRAINED {
 
 
     completition_message = ''
-    
-    if ( params.skip_homer || params.input_fasta ) {
+        
+    if ( params.skip_homer ) {
         completition_message = '\n# skipped homer for verifying motif learnt by model\n'
 
     } else {
-        CONVOLUTION_SCAN( input_fasta, model_architecture, trained_model )
+
+        // pair together the right elements of each channel
+        model          = model_architecture.combine( trained_model, by: 0 )
+        matched_imputs = input_fasta.combine( model, by: 0 )
+
+
+        CONVOLUTION_SCAN( matched_imputs )
         completition_message = CONVOLUTION_SCAN.out.standardout
 
-
-	// pair the positive set with the negative one using the motif and convolution filter number as key
-        // also retrieving the filter length from the file name
+        
+	// pair the positive set with the negative one using the motif file line and convolution filter number as key
+        // also retrieving the filter length and the motif file line from the output file name
         posive_set           = CONVOLUTION_SCAN.out.positve_set.flatten().map{ 
                                              it 
-                                                   -> [ ("${it.baseName}".split('_')[0] + '_' + "${it.baseName}".split('_')[-2]), \
+                                                   -> [ "${it.baseName}".split("__")[0], \
+                                                      "${it.baseName}".split('_')[-2], \
                                                       "${it.baseName}".split('_')[-1], \
                                                       it ] }
         negative_set         = CONVOLUTION_SCAN.out.negative_set.flatten().map{ 
                                              it
-                                                   -> [ ("${it.baseName}".split('_')[0] + '_' + "${it.baseName}".split('_')[-2]), \
+                                                   -> [ "${it.baseName}".split("__")[0],
+                                                      "${it.baseName}".split('_')[-2], \
                                                       "${it.baseName}".split('_')[-1], \
                                                       it ] }
-	paired_sets          = posive_set.combine( negative_set, by:[0, 1] )
-
-
+	paired_sets          = posive_set.combine( negative_set, by:[0, 1, 2] )
+        
+        
         // Handle the case when there is no jaspar db in input
 	if ( params.jaspar ) {
-		HOMER_FIND_JASPAR_MOTIF( paired_sets, jaspar_db )
+                
+                // pair also the correct jaspar pwm downloaded with his corresponding trained model sets
+                homer_inputs = paired_sets.combine( jaspar_db, by: 0 )
+
+    
+		HOMER_FIND_JASPAR_MOTIF( homer_inputs )
 		completition_message.concat( HOMER_FIND_JASPAR_MOTIF.out.standardout )
+
 	} else {
 		HOMER_FIND_MOTIF( paired_sets )
 		completition_message.concat( HOMER_FIND_MOTIF.out.standardout ).view()
 	}
-    
+        
     }
-
+   
 
     emit:
 


### PR DESCRIPTION
the pipeline now works on the lines of the input motif or jaspar id file. Meaning it splits the input/s file/s line by line creates an unique id associated with them and then works on parallel (when it is possible) on each line. For each line it creates and enriches with the requested motif/s, (the multiple motif enrichment is not implemented at the level of python but it is allocated at the level of nextflow, meaning it should not be any further work on the nextflow side). 

There is going to be a separate training / tuning / homer anlaysis for each of the generated fastas (so for each line).  So a different output directory structure organization was necessary: simply inside the output dir there are goung to be subdirs with unique name based on the input file and the line of interest, inside each subdir there are going to be all the files associated to such unit of information. 

The description and hellp section are still missing but will be there next update.  